### PR TITLE
Add method to get the current scope of the logger

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -95,6 +95,13 @@ export class Logger<TLogScope extends {} = {}> {
   }
 
   /**
+   * Get the current scope of the logger.
+   */
+  public getCurrentScope() {
+    return this._scope;
+  }
+
+  /**
    * Logs an `LogLevel.ERROR` message.
    */
   public error(message: string, meta?: LogMeta): void {


### PR DESCRIPTION
Motivation: sometimes it's useful to get the current logger scope, for example when saving task execution details to a database.
