### PR TITLE
Read envvar at start, not each log

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,9 @@ export const LogLevel = {
 };
 ```
 
+`process.env.GRAPHILE_LOGGER_DEBUG` is now checked once on startup, rather than
+for each log message.
+
 ### 0.2.0
 
 Fixed log scope to be more type safe

--- a/src/index.ts
+++ b/src/index.ts
@@ -164,6 +164,9 @@ export interface ConsoleLogConfig<TLogScope> {
   ): Array<unknown>;
 }
 
+// Reading envvars is expensive; cache it.
+const omitDebugLogs = !process.env.GRAPHILE_LOGGER_DEBUG;
+
 /**
  * Lets you build a console log factory with custom log formatter. Only logs
  * `DEBUG` level messages if the `GRAPHILE_LOGGER_DEBUG` environmental variable
@@ -179,7 +182,7 @@ export function makeConsoleLogFactory<TLogScope extends {}>(
 ): LogFunctionFactory<TLogScope> {
   return function consoleLogFactory(scope) {
     return (level, message, meta) => {
-      if (level === "debug" && !process.env.GRAPHILE_LOGGER_DEBUG) {
+      if (omitDebugLogs && level === "debug") {
         return;
       }
 


### PR DESCRIPTION
Reading envvars is expensive, let's just do it once on startup.

(Potentially breaking change if you're dynamically writing to `process.env` (not recommended!))